### PR TITLE
added a regex check to ensure my vim swp files arent loaded

### DIFF
--- a/utils/helperMethods.js
+++ b/utils/helperMethods.js
@@ -2,6 +2,12 @@ var fs = require('fs'),
     path = require('path');
 
 module.exports = exports = function (shell) {
+
+    // regex to test if file name is valid
+    // used to prevent loading non-js file that are in cmd-dir
+    // example would be an IDE creating .tmp or .swp files
+    var jsFileRegexTest = /([a-zA-Z0-9_-])\.js$/i; 
+    
     // Load specified command module into shell.cmds.
     shell.loadCommandModule = function(cmdPath) {
         try {
@@ -26,7 +32,9 @@ module.exports = exports = function (shell) {
             var files = fs.readdirSync(dir);
             if (files)
                 files.forEach(function (file) {
-                    shell.loadCommandModule(path.resolve(dir, file));
+                    if(jsFileRegexTest.test(file)){
+                        shell.loadCommandModule(path.resolve(dir, file));
+                    }
                 });
         }
         return shell;


### PR DESCRIPTION
fix for issue #15 where my vim .swp files were being auto-loaded as command modules.

I put together a basic regex check, didn't spend that much time thinking out edge cases so outstanding issues may exist.  let me know if you want any adjustments to it.
