### PR TITLE
Bug fix: Missing break statement in command invoke logic

### DIFF
--- a/utils/execute.js
+++ b/utils/execute.js
@@ -78,6 +78,7 @@ module.exports = exports = function (cmdStr, contextData, options) {
                                 if (err) shell.error(err);
                                 shell.emit('done');
                             });
+                            break;
                         default:
                             // Invoke is not asynchronous so do not pass in a callback.
                             cmd.invoke(shell, options);


### PR DESCRIPTION
For async invoke calls the default syn logic was also executed.  This is a fix.
